### PR TITLE
상품 조회 totalPages 계산 오류 수정

### DIFF
--- a/src/main/java/e3i2/ecommerce_backoffice/domain/product/repository/ProductRepository.java
+++ b/src/main/java/e3i2/ecommerce_backoffice/domain/product/repository/ProductRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
@@ -24,7 +25,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             @Param("productName") String productName
             , @Param("category") ProductCategory category
             , @Param("status") ProductStatus status
-            , Pageable pageable);
+            , Pageable pageable
+    );
 
     Optional<Product> findByProductIdAndDeletedFalse(Long productId);
 }


### PR DESCRIPTION
fix: totalPages 계산 오류 수정
refactor: 상품 삭제시 의미 없는 admin 변수 삭제

# Work History
상품 조회 totalPages 계산 오류 수정
total 값을 size로 직접 넘겨서 그 페이지의 항목 수 만큼만 넘어가고 있었음
getTotalElements 내부 메서드 사용으로 해결

# Releated Issue
Fixes #9 

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC